### PR TITLE
Fix SQL-safe table naming and connection pool management

### DIFF
--- a/langconnect/database/collections.py
+++ b/langconnect/database/collections.py
@@ -126,8 +126,9 @@ class CollectionsManager:
         metadata["owner_id"] = self.user_id
         metadata["name"] = collection_name
 
-        # For now just assign a random table id
-        table_id = str(uuid.uuid4())
+        # For now assign a table identifier safe for SQL naming
+        # Use hex string and prefix to avoid leading digits/hyphens
+        table_id = f"tbl_{uuid.uuid4().hex}"
 
         # triggers PGVector to create both the vectorstore and DB entry
         get_vectorstore(table_id, collection_metadata=metadata)

--- a/langconnect/database/connection.py
+++ b/langconnect/database/connection.py
@@ -44,13 +44,10 @@ async def close_db_pool():
 
 @asynccontextmanager
 async def get_db_connection() -> AsyncGenerator[asyncpg.Connection, None]:
-    """Get a connection from the pool."""
+    """Acquire a connection from the pool and release it when done."""
     pool = await get_db_pool()
     async with pool.acquire() as conn:
-        try:
-            yield conn
-        finally:
-            await conn.close()
+        yield conn
 
 
 def get_vectorstore_engine(


### PR DESCRIPTION
## Summary
- Fixed table naming to be SQL-safe by using hex UUID format with 'tbl_' prefix
- Cleaned up redundant connection closing in database connection pool management

## Changes
1. **Table Naming Fix** (`collections.py`):
   - Changed from `str(uuid.uuid4())` which contains hyphens
   - Now uses `f"tbl_{uuid.uuid4().hex}"` for SQL-safe naming
   - Prevents issues with hyphens and potential leading digits in table names

2. **Connection Pool Cleanup** (`connection.py`):
   - Removed redundant `try/finally` block with `await conn.close()`
   - The `pool.acquire()` context manager already handles connection lifecycle
   - Simplified code and improved clarity

## Test Plan
- [ ] Verify new collections create tables with proper naming format
- [ ] Confirm database connections are properly released without explicit closing
- [ ] Run existing test suite to ensure no regressions

🤖 Generated with [Claude Code](https://claude.ai/code)