### PR TITLE
feat: Add multi-language support (English/Korean)

### DIFF
--- a/next-connect-ui/src/app/(protected)/collections/page.tsx
+++ b/next-connect-ui/src/app/(protected)/collections/page.tsx
@@ -21,8 +21,10 @@ import {
   AlertDialogTrigger,
 } from '@/components/ui/alert-dialog'
 import { CreateCollectionModal } from '@/components/modals/create-collection-modal'
+import { useTranslation } from '@/hooks/use-translation'
 
 export default function CollectionsPage() {
+  const { t } = useTranslation()
   const [collections, setCollections] = useState<CollectionWithStats[]>([])
   const [loading, setLoading] = useState(true)
   const [refreshing, setRefreshing] = useState(false)
@@ -44,8 +46,8 @@ export default function CollectionsPage() {
       const response = await fetch('/api/collections')
       const res = await response.json()
       if (!res.success) {
-        toast.error("컬렉션 오류", {
-          description: "컬렉션 조회 실패"
+        toast.error(t("common.error"), {
+          description: t("collections.messages.fetchError")
         })
         return
       }
@@ -131,11 +133,11 @@ export default function CollectionsPage() {
       setLoading(false)
       setRefreshing(false)
     }
-  }, [])
+  }, [t])
 
   useEffect(() => {
     fetchCollections()
-  }, [fetchCollections])
+  }, [fetchCollections, t])
 
   const handleRefresh = () => {
     setRefreshing(true)
@@ -179,14 +181,14 @@ export default function CollectionsPage() {
     setSelectedCollections([])
 
     if (deletedCount > 0) {
-      alert(`✅ ${deletedCount}개의 컬렉션이 성공적으로 삭제되었습니다.`)
+      alert(`✅ ${t('collections.messages.deleteSuccess', { count: deletedCount })}`)
     }
     if (failedCount > 0) {
-      alert(`❌ ${failedCount}개의 컬렉션 삭제에 실패했습니다.`)
+      alert(`❌ ${t('collections.messages.deleteFailed', { count: failedCount })}`)
     }
 
     fetchCollections()
-  }, [selectedCollections, fetchCollections])
+  }, [selectedCollections, fetchCollections, t])
 
   const toggleSelection = (uuid: string) => {
     setSelectedCollections(prev => 
@@ -254,16 +256,16 @@ export default function CollectionsPage() {
         <div className="rounded-full bg-blue-50 dark:bg-blue-900/20 p-6 mb-4">
           <FolderOpen className="h-12 w-12 text-blue-500" />
         </div>
-        <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-2">컬렉션이 없습니다</h3>
+        <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-2">{t('collections.noCollections')}</h3>
         <p className="text-gray-500 dark:text-gray-300 text-center mb-6 max-w-sm">
-          첫 번째 컬렉션을 생성하여 문서들을 체계적으로 관리해보세요.
+          {t('collections.noCollectionsDescription')}
         </p>
         <Button 
           onClick={() => setShowCreateModal(true)}
           className="bg-gradient-to-r from-blue-500 to-indigo-500 hover:from-blue-600 hover:to-indigo-600"
         >
           <Plus className="w-4 h-4 mr-2" />
-          첫 컬렉션 만들기
+          {t('collections.createFirstCollection')}
         </Button>
       </CardContent>
     </Card>
@@ -277,9 +279,9 @@ export default function CollectionsPage() {
           <div>
             <h1 className="text-3xl font-bold bg-gradient-to-r from-gray-900 to-gray-600 dark:from-gray-100 dark:to-gray-400 bg-clip-text text-transparent flex items-center gap-3">
               <Database className="h-8 w-8 text-blue-500" />
-              컬렉션 관리
+              {t('collections.title')}
             </h1>
-            <p className="text-gray-600 dark:text-gray-300 mt-1">문서 컬렉션을 생성하고 관리하세요</p>
+            <p className="text-gray-600 dark:text-gray-300 mt-1">{t('collections.description')}</p>
           </div>
           <div className="flex items-center gap-3">
             <Button
@@ -290,7 +292,7 @@ export default function CollectionsPage() {
               className="flex items-center gap-2"
             >
               <RefreshCw className={`w-4 h-4 ${refreshing ? 'animate-spin' : ''}`} />
-              새로고침
+              {t('common.refresh')}
             </Button>
             <Button 
               onClick={() => setShowCreateModal(true)}
@@ -298,7 +300,7 @@ export default function CollectionsPage() {
               className="bg-gradient-to-r from-blue-500 to-indigo-500 hover:from-blue-600 hover:to-indigo-600 shadow-lg hover:shadow-xl transition-all duration-200"
             >
               <Plus className="w-4 h-4 mr-2" />
-              새 컬렉션
+              {t('collections.newCollection')}
             </Button>
           </div>
         </div>
@@ -318,17 +320,17 @@ export default function CollectionsPage() {
                 <div className="flex items-center gap-6">
                   <div className="flex items-center gap-2">
                     <Database className="h-4 w-4 text-blue-500" />
-                    <span className="text-sm text-gray-600 dark:text-gray-300">컬렉션</span>
+                    <span className="text-sm text-gray-600 dark:text-gray-300">{t('collections.stats.collections')}</span>
                     <span className="font-semibold text-gray-900 dark:text-gray-100">{collections.length}</span>
                   </div>
                   <div className="flex items-center gap-2">
                     <FileText className="h-4 w-4 text-green-500" />
-                    <span className="text-sm text-gray-600 dark:text-gray-300">문서</span>
+                    <span className="text-sm text-gray-600 dark:text-gray-300">{t('collections.stats.documents')}</span>
                     <span className="font-semibold text-gray-900 dark:text-gray-100">{totalDocuments}</span>
                   </div>
                   <div className="flex items-center gap-2">
                     <Archive className="h-4 w-4 text-purple-500" />
-                    <span className="text-sm text-gray-600 dark:text-gray-300">청크</span>
+                    <span className="text-sm text-gray-600 dark:text-gray-300">{t('collections.stats.chunks')}</span>
                     <span className="font-semibold text-gray-900 dark:text-gray-100">{totalChunks}</span>
                   </div>
                 </div>
@@ -342,12 +344,12 @@ export default function CollectionsPage() {
                   <div className="flex flex-col items-center gap-2">
                     <CardTitle className="flex items-center gap-2">
                       <BookOpen className="h-5 w-5 text-blue-500" />
-                      컬렉션 목록
+                      {t('collections.collectionList')}
                     </CardTitle>
                     <CardDescription>
                       {selectedCollections.length > 0 
-                        ? `${selectedCollections.length}개 선택됨` 
-                        : `총 ${collections.length}개의 컬렉션`}
+                        ? t('common.selected', { count: selectedCollections.length }) 
+                        : t('common.total', { count: collections.length }) + ' ' + t('collections.stats.collections').toLowerCase()}
                     </CardDescription>
                   </div>
                   
@@ -356,19 +358,19 @@ export default function CollectionsPage() {
                       <AlertDialogTrigger asChild>
                         <Button variant="destructive" size="sm" className="flex items-center gap-2">
                           <Trash2 className="w-4 h-4" />
-                          선택 항목 삭제
+                          {t('collections.deleteConfirm.deleteSelected')}
                         </Button>
                       </AlertDialogTrigger>
                       <AlertDialogContent>
                         <AlertDialogHeader>
-                          <AlertDialogTitle>삭제 확인</AlertDialogTitle>
+                          <AlertDialogTitle>{t('collections.deleteConfirm.title')}</AlertDialogTitle>
                           <AlertDialogDescription>
-                            ⚠️ 정말로 선택한 컬렉션을 삭제하시겠습니까? <strong>이 작업은 복구할 수 없습니다.</strong>
+                            ⚠️ {t('collections.deleteConfirm.description')}
                           </AlertDialogDescription>
                         </AlertDialogHeader>
                         <div className="my-4">
                           <p className="text-sm text-gray-600 dark:text-gray-300 mb-2">
-                            삭제할 컬렉션 ({selectedCollections.length}개):
+                            {t('collections.deleteConfirm.collectionsToDelete', { count: selectedCollections.length })}
                           </p>
                           <ul className="text-sm text-gray-700 dark:text-gray-300 mb-3 list-disc pl-5">
                             {selectedCollectionNames.map((name, idx) => (
@@ -376,11 +378,11 @@ export default function CollectionsPage() {
                             ))}
                           </ul>
                           <div className="text-sm text-blue-600 dark:text-blue-400 bg-blue-50 dark:bg-blue-900/20 p-2 rounded">
-                            ℹ️ 삭제된 컬렉션의 모든 문서도 함께 삭제됩니다.
+                            ℹ️ {t('collections.deleteConfirm.warningMessage')}
                           </div>
                         </div>
                         <AlertDialogFooter>
-                          <AlertDialogCancel disabled={deleting}>취소</AlertDialogCancel>
+                          <AlertDialogCancel disabled={deleting}>{t('common.cancel')}</AlertDialogCancel>
                           <AlertDialogAction
                             onClick={handleDeleteSelected}
                             disabled={deleting}
@@ -389,10 +391,10 @@ export default function CollectionsPage() {
                             {deleting ? (
                               <>
                                 <Loader2 className="w-4 h-4 animate-spin mr-2" />
-                                삭제 중...
+                                {t('collections.deleteConfirm.deleting')}
                               </>
                             ) : (
-                              '삭제'
+                              t('collections.deleteConfirm.deleteButton')
                             )}
                           </AlertDialogAction>
                         </AlertDialogFooter>
@@ -421,16 +423,16 @@ export default function CollectionsPage() {
                           />
                         </th>
                         <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">
-                          컬렉션
+                          {t('collections.table.collection')}
                         </th>
                         <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">
-                          통계
+                          {t('collections.table.stats')}
                         </th>
                         <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">
-                          UUID
+                          {t('collections.table.uuid')}
                         </th>
                         <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">
-                          메타데이터
+                          {t('collections.table.metadata')}
                         </th>
                       </tr>
                     </thead>
@@ -487,7 +489,7 @@ export default function CollectionsPage() {
                                       <div className="space-y-4">
                                         {/* 기본 정보 */}
                                         <div>
-                                          <h4 className="font-medium text-sm text-gray-600 dark:text-gray-300 mb-2">기본 정보</h4>
+                                          <h4 className="font-medium text-sm text-gray-600 dark:text-gray-300 mb-2">{t('collections.popover.basicInfo')}</h4>
                                           <div className="space-y-2 text-sm">
                                             <div className="flex justify-between">
                                               <span className="text-gray-500 dark:text-gray-300">UUID:</span>
@@ -500,12 +502,12 @@ export default function CollectionsPage() {
 
                                         {/* 통계 정보 */}
                                         <div>
-                                          <h4 className="font-medium text-sm text-gray-600 dark:text-gray-300 mb-2">통계</h4>
+                                          <h4 className="font-medium text-sm text-gray-600 dark:text-gray-300 mb-2">{t('collections.popover.statistics')}</h4>
                                           <div className="grid grid-cols-2 gap-3">
                                             <div className="bg-blue-50 dark:bg-blue-900/20 p-3 rounded-lg">
                                               <div className="flex items-center gap-2 mb-1">
                                                 <FileText className="h-4 w-4 text-blue-500" />
-                                                <span className="text-sm font-medium text-blue-700 dark:text-blue-300">문서</span>
+                                                <span className="text-sm font-medium text-blue-700 dark:text-blue-300">{t('collections.stats.documents')}</span>
                                               </div>
                                               <div className="text-lg font-bold text-blue-900 dark:text-blue-100">
                                                 {collection.stats.documents}
@@ -514,7 +516,7 @@ export default function CollectionsPage() {
                                             <div className="bg-purple-50 dark:bg-purple-900/20 p-3 rounded-lg">
                                               <div className="flex items-center gap-2 mb-1">
                                                 <Archive className="h-4 w-4 text-purple-500" />
-                                                <span className="text-sm font-medium text-purple-700 dark:text-purple-300">청크</span>
+                                                <span className="text-sm font-medium text-purple-700 dark:text-purple-300">{t('collections.stats.chunks')}</span>
                                               </div>
                                               <div className="text-lg font-bold text-purple-900 dark:text-purple-100">
                                                 {collection.stats.chunks}
@@ -526,7 +528,7 @@ export default function CollectionsPage() {
                                         {/* 메타데이터 */}
                                         {collection.metadata && Object.keys(collection.metadata).length > 0 && (
                                           <div>
-                                            <h4 className="font-medium text-sm text-gray-600 dark:text-gray-300 mb-2">메타데이터</h4>
+                                            <h4 className="font-medium text-sm text-gray-600 dark:text-gray-300 mb-2">{t('collections.table.metadata')}</h4>
                                             <pre className="text-xs bg-gray-50 dark:bg-gray-800 p-3 rounded overflow-x-auto whitespace-pre-wrap">
                                               {JSON.stringify(collection.metadata, null, 2)}
                                             </pre>
@@ -543,10 +545,10 @@ export default function CollectionsPage() {
                             <div className="flex items-center space-x-2">
                               <Badge variant="secondary" className="text-xs">
                                 <FileText className="w-3 h-3 mr-1" />
-                                {collection.stats.documents} 문서
+                                {t('collections.stats.documentsCount', { count: collection.stats.documents })}
                               </Badge>
                               <Badge variant="outline" className="text-xs">
-                                {collection.stats.chunks} 청크
+                                {t('collections.stats.chunksCount', { count: collection.stats.chunks })}
                               </Badge>
                             </div>
                           </td>
@@ -562,7 +564,7 @@ export default function CollectionsPage() {
                                   {JSON.stringify(collection.metadata)}
                                 </code>
                               ) : (
-                                <span className="text-gray-400 dark:text-gray-400 italic">없음</span>
+                                <span className="text-gray-400 dark:text-gray-400 italic">{t('common.none')}</span>
                               )}
                             </div>
                           </td>

--- a/next-connect-ui/src/app/(protected)/collections/page.tsx
+++ b/next-connect-ui/src/app/(protected)/collections/page.tsx
@@ -133,11 +133,12 @@ export default function CollectionsPage() {
       setLoading(false)
       setRefreshing(false)
     }
-  }, [t])
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
 
   useEffect(() => {
     fetchCollections()
-  }, [fetchCollections, t])
+  }, [fetchCollections])
 
   const handleRefresh = () => {
     setRefreshing(true)
@@ -188,7 +189,8 @@ export default function CollectionsPage() {
     }
 
     fetchCollections()
-  }, [selectedCollections, fetchCollections, t])
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [selectedCollections, fetchCollections])
 
   const toggleSelection = (uuid: string) => {
     setSelectedCollections(prev => 

--- a/next-connect-ui/src/app/layout.tsx
+++ b/next-connect-ui/src/app/layout.tsx
@@ -3,6 +3,7 @@ import type { Metadata } from "next"
 import "./globals.css"
 import { ThemeProvider } from "@/providers/theme-provider"
 import AuthProvider from "@/providers/auth-provider"
+import { LanguageProvider } from "@/providers/language-provider"
 import { Toaster as SonnerToaster } from "sonner"
 
 export const metadata: Metadata = {
@@ -16,11 +17,13 @@ export default function RootLayout({
   children: React.ReactNode
 }>) {
   return (
-    <html lang="ko" suppressHydrationWarning>
+    <html lang="en" suppressHydrationWarning>
       <body className="min-h-screen overflow-hidden">
         <ThemeProvider attribute="class" defaultTheme="system" enableSystem disableTransitionOnChange>
           <AuthProvider>
-            {children}
+            <LanguageProvider>
+              {children}
+            </LanguageProvider>
           </AuthProvider>
           <SonnerToaster />
         </ThemeProvider>

--- a/next-connect-ui/src/components/layout/app-sidebar.tsx
+++ b/next-connect-ui/src/components/layout/app-sidebar.tsx
@@ -7,6 +7,7 @@ import {
   Home,
   Database,
   Code,
+  Globe,
 } from "lucide-react"
 import {
   Sidebar,
@@ -17,40 +18,51 @@ import {
   SidebarMenuButton,
   SidebarMenuItem,
 } from "@/components/ui/sidebar"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
 import { NavMain } from "./nav-main"
 import { NavUser } from "./nav-user"
 import Link from "next/link"
+import { useTranslation } from "@/hooks/use-translation"
+import { useLanguage } from "@/providers/language-provider"
 
 export function AppSidebar() {
   const pathname = usePathname()
+  const { t } = useTranslation()
+  const { language, setLanguage } = useLanguage()
 
   const mainItems = [
     {
-      name: "메인",
+      name: t("sidebar.main"),
       href: "/",
       icon: Home,
       isActive: pathname === "/",
     },
     {
-      name: "컬렉션",
+      name: t("sidebar.collections"),
       href: "/collections",
       icon: Database,
       isActive: pathname.startsWith("/collections"),
     },
     {
-      name: "문서",
+      name: t("sidebar.documents"),
       href: "/documents",
       icon: FileText,
       isActive: pathname.startsWith("/documents"),
     },
     {
-      name: "검색",
+      name: t("sidebar.search"),
       href: "/search",
       icon: Search,
       isActive: pathname.startsWith("/search"),
     },
     {
-      name: "API 테스터",
+      name: t("sidebar.apiTester"),
       href: "/api-tester",
       icon: Code,
       isActive: pathname.startsWith("/api-tester"),
@@ -75,9 +87,27 @@ export function AppSidebar() {
           </SidebarMenu>
         </SidebarHeader>
         <SidebarContent>
-          <NavMain title="메인" items={mainItems} />
+          <NavMain title={t("sidebar.mainTitle")} items={mainItems} />
         </SidebarContent>
         <SidebarFooter>
+          <SidebarMenu>
+            <SidebarMenuItem>
+              <div className="px-3 py-2">
+                <Select value={language} onValueChange={(value: 'en' | 'ko') => setLanguage(value)}>
+                  <SelectTrigger className="w-full h-9">
+                    <div className="flex items-center gap-2">
+                      <Globe className="h-4 w-4" />
+                      <SelectValue />
+                    </div>
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="en">{t("language.english")}</SelectItem>
+                    <SelectItem value="ko">{t("language.korean")}</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+            </SidebarMenuItem>
+          </SidebarMenu>
           <NavUser />
         </SidebarFooter>
       </Sidebar>

--- a/next-connect-ui/src/components/layout/nav-user.tsx
+++ b/next-connect-ui/src/components/layout/nav-user.tsx
@@ -23,17 +23,18 @@ import { useSession } from "next-auth/react"
 import { useAuth } from "@/hooks/use-auth"
 import { useCallback } from "react"
 import { useRouter } from "next/navigation"
+import { useTranslation } from "@/hooks/use-translation"
 
 export function NavUser() {
   const { isMobile } = useSidebar()
   const { data: session } = useSession()
   const { logout } = useAuth()
   const router = useRouter()
+  const { t } = useTranslation()
 
   const handleLogout = useCallback(async () => {
     const result = await logout();
     if (result.success) {
-      // 로그아웃 성공 시 로그인 페이지로 강제 이동
       router.push('/signin');
     }
   }, [logout, router])
@@ -71,7 +72,7 @@ export function NavUser() {
             <DropdownMenuSeparator />
             <DropdownMenuItem onClick={handleLogout}>
               <LogOut />
-              Log out
+              {t("common.logout")}
             </DropdownMenuItem>
           </DropdownMenuContent>
         </DropdownMenu>

--- a/next-connect-ui/src/components/modals/create-collection-modal.tsx
+++ b/next-connect-ui/src/components/modals/create-collection-modal.tsx
@@ -24,10 +24,11 @@ import { Form, FormControl, FormDescription, FormField, FormItem, FormLabel, For
 import { Input } from "@/components/ui/input"
 import { Textarea } from "@/components/ui/textarea"
 import { toast } from "sonner"
+import { useTranslation } from "@/hooks/use-translation"
 
-const formSchema = z.object({
+const createFormSchema = (t: (key: string) => string) => z.object({
   name: z.string().min(1, {
-    message: "컬렉션 이름을 입력해주세요.",
+    message: t('collections.modal.namePlaceholder'),
   }),
   metadata: z.string().refine((value) => {
     try {
@@ -37,7 +38,7 @@ const formSchema = z.object({
       return false
     }
   }, {
-    message: "올바른 JSON 형식을 입력해주세요.",
+    message: "Invalid JSON format",
   }),
 })
 
@@ -48,7 +49,9 @@ interface CreateCollectionModalProps {
 }
 
 export function CreateCollectionModal({ open, onOpenChange, onSuccess }: CreateCollectionModalProps) {
+  const { t } = useTranslation()
   const [isLoading, setIsLoading] = useState(false)
+  const formSchema = createFormSchema(t)
 
   const form = useForm<z.infer<typeof formSchema>>({
     resolver: zodResolver(formSchema),
@@ -73,11 +76,11 @@ export function CreateCollectionModal({ open, onOpenChange, onSuccess }: CreateC
       const result = await response.json()
 
       if (!result.success) {
-        throw new Error(result.message || '컬렉션 생성에 실패했습니다.')
+        throw new Error(result.message || t('collections.modal.createError'))
       }
 
-      toast.success("컬렉션 생성 완료", {
-        description: `'${values.name}' 컬렉션이 성공적으로 생성되었습니다.`,
+      toast.success(t('common.success'), {
+        description: t('collections.modal.createSuccess'),
       })
       
       onOpenChange(false)
@@ -85,8 +88,8 @@ export function CreateCollectionModal({ open, onOpenChange, onSuccess }: CreateC
       onSuccess?.()
     } catch (error: any) {
       console.error("Failed to create collection:", error)
-      toast.error("컬렉션 생성 실패", {
-        description: error.message || "컬렉션 생성 중 오류가 발생했습니다.",
+      toast.error(t('common.error'), {
+        description: error.message || t('collections.modal.createError'),
       })
     } finally {
       setIsLoading(false)
@@ -108,10 +111,10 @@ export function CreateCollectionModal({ open, onOpenChange, onSuccess }: CreateC
             </div>
             <div>
               <DialogTitle className="text-xl bg-gradient-to-r from-blue-600 to-indigo-600 dark:from-blue-400 dark:to-indigo-400 bg-clip-text text-transparent">
-                새 컬렉션 생성
+                {t('collections.modal.createTitle')}
               </DialogTitle>
               <DialogDescription className="text-muted-foreground dark:text-gray-300">
-                새로운 문서 컬렉션을 생성합니다. 컬렉션 이름과 메타데이터를 입력해주세요.
+                {t('collections.modal.createTitle')}
               </DialogDescription>
             </div>
             <div className="ml-auto">
@@ -130,17 +133,17 @@ export function CreateCollectionModal({ open, onOpenChange, onSuccess }: CreateC
                   <FormItem>
                     <FormLabel className="flex items-center gap-2">
                       <Folder className="h-4 w-4 text-blue-500" />
-                      컬렉션 이름
+                      {t('collections.modal.nameLabel')}
                     </FormLabel>
                     <FormControl>
                       <Input 
-                        placeholder="컬렉션 이름을 입력하세요" 
+                        placeholder={t('collections.modal.namePlaceholder')} 
                         className="transition-all duration-200 focus:ring-2 focus:ring-blue-500/20 focus:border-blue-500" 
                         {...field} 
                       />
                     </FormControl>
                     <FormDescription className="text-gray-500 dark:text-gray-300">
-                      문서들을 그룹화할 컬렉션의 이름을 입력하세요.
+                      {t('collections.modal.descriptionPlaceholder')}
                     </FormDescription>
                     <FormMessage />
                   </FormItem>
@@ -154,7 +157,7 @@ export function CreateCollectionModal({ open, onOpenChange, onSuccess }: CreateC
                   <FormItem>
                     <FormLabel className="flex items-center gap-2">
                       <Code className="h-4 w-4 text-emerald-500" />
-                      메타데이터 (JSON)
+                      {t('collections.table.metadata')} (JSON)
                     </FormLabel>
                     <FormControl>
                       <Textarea 
@@ -164,7 +167,7 @@ export function CreateCollectionModal({ open, onOpenChange, onSuccess }: CreateC
                       />
                     </FormControl>
                     <FormDescription className="text-gray-500 dark:text-gray-300">
-                      컬렉션에 대한 추가 정보를 JSON 형식으로 입력하세요.
+                      {t('collections.modal.descriptionPlaceholder')}
                     </FormDescription>
                     <FormMessage />
                   </FormItem>
@@ -180,7 +183,7 @@ export function CreateCollectionModal({ open, onOpenChange, onSuccess }: CreateC
                     disabled={isLoading}
                     className="flex-1 sm:flex-initial"
                   >
-                    취소
+                    {t('common.cancel')}
                   </Button>
                   <Button 
                     type="submit" 
@@ -191,12 +194,12 @@ export function CreateCollectionModal({ open, onOpenChange, onSuccess }: CreateC
                     {isLoading ? (
                       <>
                         <div className="mr-2 h-4 w-4 animate-spin rounded-full border-2 border-white/30 border-t-white" />
-                        생성 중...
+                        {t('collections.modal.creating')}
                       </>
                     ) : (
                       <>
                         <Plus className="mr-2 h-4 w-4" />
-                        컬렉션 생성
+                        {t('collections.modal.createTitle')}
                       </>
                     )}
                   </Button>

--- a/next-connect-ui/src/hooks/use-translation.ts
+++ b/next-connect-ui/src/hooks/use-translation.ts
@@ -1,0 +1,30 @@
+import { useLanguage } from '@/providers/language-provider'
+import { en } from '@/translations/en'
+import { ko } from '@/translations/ko'
+
+type TranslationKeys = typeof en
+
+function getNestedValue(obj: any, path: string): string {
+  return path.split('.').reduce((acc, part) => acc && acc[part], obj) || path
+}
+
+function interpolate(text: string, values: Record<string, any>): string {
+  return text.replace(/\{\{(\w+)\}\}/g, (match, key) => {
+    return values[key] !== undefined ? String(values[key]) : match
+  })
+}
+
+export function useTranslation() {
+  const { language } = useLanguage()
+  const translations: TranslationKeys = language === 'ko' ? ko : en
+
+  const t = (key: string, values?: Record<string, any>): string => {
+    const translation = getNestedValue(translations, key)
+    if (values) {
+      return interpolate(translation, values)
+    }
+    return translation
+  }
+
+  return { t, language }
+}

--- a/next-connect-ui/src/providers/language-provider.tsx
+++ b/next-connect-ui/src/providers/language-provider.tsx
@@ -1,0 +1,52 @@
+'use client'
+
+import React, { createContext, useContext, useState, useEffect, ReactNode } from 'react'
+
+export type Language = 'en' | 'ko'
+
+interface LanguageContextType {
+  language: Language
+  setLanguage: (language: Language) => void
+}
+
+const LanguageContext = createContext<LanguageContextType | undefined>(undefined)
+
+interface LanguageProviderProps {
+  children: ReactNode
+}
+
+export function LanguageProvider({ children }: LanguageProviderProps) {
+  const [language, setLanguageState] = useState<Language>('en')
+  const [isLoaded, setIsLoaded] = useState(false)
+
+  useEffect(() => {
+    const storedLanguage = localStorage.getItem('language') as Language
+    if (storedLanguage && (storedLanguage === 'en' || storedLanguage === 'ko')) {
+      setLanguageState(storedLanguage)
+    }
+    setIsLoaded(true)
+  }, [])
+
+  const setLanguage = (newLanguage: Language) => {
+    setLanguageState(newLanguage)
+    localStorage.setItem('language', newLanguage)
+  }
+
+  if (!isLoaded) {
+    return null
+  }
+
+  return (
+    <LanguageContext.Provider value={{ language, setLanguage }}>
+      {children}
+    </LanguageContext.Provider>
+  )
+}
+
+export function useLanguage() {
+  const context = useContext(LanguageContext)
+  if (context === undefined) {
+    throw new Error('useLanguage must be used within a LanguageProvider')
+  }
+  return context
+}

--- a/next-connect-ui/src/translations/en.ts
+++ b/next-connect-ui/src/translations/en.ts
@@ -1,0 +1,161 @@
+export const en = {
+  common: {
+    loading: 'Loading...',
+    error: 'Error',
+    success: 'Success',
+    cancel: 'Cancel',
+    save: 'Save',
+    delete: 'Delete',
+    edit: 'Edit',
+    create: 'Create',
+    search: 'Search',
+    refresh: 'Refresh',
+    logout: 'Log out',
+    none: 'None',
+    selectAll: 'Select all',
+    selected: '{{count}} selected',
+    total: 'Total {{count}}',
+  },
+  sidebar: {
+    main: 'Main',
+    collections: 'Collections',
+    documents: 'Documents',
+    search: 'Search',
+    apiTester: 'API Tester',
+    mainTitle: 'Main'
+  },
+  collections: {
+    title: 'Collection Management',
+    description: 'Create and manage document collections',
+    newCollection: 'New Collection',
+    collectionList: 'Collection List',
+    noCollections: 'No collections',
+    noCollectionsDescription: 'Create your first collection to organize documents systematically.',
+    createFirstCollection: 'Create First Collection',
+    stats: {
+      collections: 'Collections',
+      documents: 'Documents',
+      chunks: 'Chunks',
+      documentsCount: '{{count}} documents',
+      chunksCount: '{{count}} chunks'
+    },
+    table: {
+      collection: 'Collection',
+      stats: 'Statistics',
+      uuid: 'UUID',
+      metadata: 'Metadata'
+    },
+    deleteConfirm: {
+      title: 'Delete Confirmation',
+      description: 'Are you sure you want to delete the selected collections? This action cannot be undone.',
+      collectionsToDelete: 'Collections to delete ({{count}}):',
+      warningMessage: 'All documents in the deleted collections will also be deleted.',
+      deleteButton: 'Delete',
+      deleting: 'Deleting...',
+      deleteSelected: 'Delete Selected'
+    },
+    popover: {
+      basicInfo: 'Basic Information',
+      statistics: 'Statistics'
+    },
+    messages: {
+      fetchError: 'Failed to fetch collections',
+      deleteSuccess: '{{count}} collections successfully deleted.',
+      deleteFailed: '{{count}} collections failed to delete.'
+    },
+    modal: {
+      createTitle: 'Create New Collection',
+      nameLabel: 'Collection Name',
+      namePlaceholder: 'Enter collection name',
+      descriptionLabel: 'Description',
+      descriptionPlaceholder: 'Enter collection description (optional)',
+      creating: 'Creating...',
+      createSuccess: 'Collection created successfully',
+      createError: 'Failed to create collection'
+    }
+  },
+  documents: {
+    title: 'Document Management',
+    description: 'Upload and manage documents in collections',
+    selectCollection: 'Please select a collection first',
+    uploadDocument: 'Upload Document',
+    noDocuments: 'No documents',
+    noDocumentsDescription: 'Upload your first document to this collection.',
+    uploadFirstDocument: 'Upload First Document',
+    table: {
+      fileName: 'File Name',
+      uploadDate: 'Upload Date',
+      chunks: 'Chunks',
+      actions: 'Actions'
+    },
+    deleteConfirm: {
+      title: 'Delete Document',
+      description: 'Are you sure you want to delete "{{fileName}}"? This action cannot be undone.',
+      warningMessage: 'All chunks associated with this document will also be deleted.'
+    },
+    messages: {
+      uploadSuccess: 'Document uploaded successfully',
+      uploadError: 'Failed to upload document',
+      deleteSuccess: 'Document deleted successfully',
+      deleteError: 'Failed to delete document',
+      fetchError: 'Failed to fetch documents'
+    },
+    modal: {
+      uploadTitle: 'Upload Document',
+      selectFile: 'Select File',
+      supportedFormats: 'Supported formats: PDF, TXT, MD, DOCX, HTML',
+      uploading: 'Uploading...',
+      processing: 'Processing document...'
+    }
+  },
+  search: {
+    title: 'Document Search',
+    description: 'Search documents using semantic or keyword search',
+    selectCollection: 'Select Collection',
+    searchPlaceholder: 'Enter search query...',
+    searchButton: 'Search',
+    searching: 'Searching...',
+    searchType: 'Search Type',
+    semanticSearch: 'Semantic Search',
+    keywordSearch: 'Keyword Search',
+    hybridSearch: 'Hybrid Search',
+    alphaValue: 'Alpha value (0-1)',
+    noResults: 'No results found',
+    results: 'Search Results',
+    relevanceScore: 'Relevance: {{score}}'
+  },
+  apiTester: {
+    title: 'API Tester',
+    description: 'Test API endpoints with authentication',
+    endpoint: 'Endpoint',
+    method: 'Method',
+    headers: 'Headers',
+    body: 'Body',
+    sendRequest: 'Send Request',
+    response: 'Response',
+    responseTime: 'Response time: {{time}}ms',
+    status: 'Status'
+  },
+  auth: {
+    signIn: 'Sign In',
+    signUp: 'Sign Up',
+    email: 'Email',
+    password: 'Password',
+    confirmPassword: 'Confirm Password',
+    forgotPassword: 'Forgot Password?',
+    alreadyHaveAccount: 'Already have an account?',
+    dontHaveAccount: "Don't have an account?",
+    signInError: 'Failed to sign in',
+    signUpError: 'Failed to sign up',
+    logoutSuccess: 'Logged out successfully'
+  },
+  theme: {
+    light: 'Light',
+    dark: 'Dark',
+    system: 'System'
+  },
+  language: {
+    english: 'English',
+    korean: '한국어'
+  }
+}

--- a/next-connect-ui/src/translations/ko.ts
+++ b/next-connect-ui/src/translations/ko.ts
@@ -1,0 +1,161 @@
+export const ko = {
+  common: {
+    loading: '로딩 중...',
+    error: '오류',
+    success: '성공',
+    cancel: '취소',
+    save: '저장',
+    delete: '삭제',
+    edit: '편집',
+    create: '만들기',
+    search: '검색',
+    refresh: '새로고침',
+    logout: '로그아웃',
+    none: '없음',
+    selectAll: '전체 선택',
+    selected: '{{count}}개 선택됨',
+    total: '총 {{count}}개',
+  },
+  sidebar: {
+    main: '메인',
+    collections: '컬렉션',
+    documents: '문서',
+    search: '검색',
+    apiTester: 'API 테스터',
+    mainTitle: '메인'
+  },
+  collections: {
+    title: '컬렉션 관리',
+    description: '문서 컬렉션을 생성하고 관리하세요',
+    newCollection: '새 컬렉션',
+    collectionList: '컬렉션 목록',
+    noCollections: '컬렉션이 없습니다',
+    noCollectionsDescription: '첫 번째 컬렉션을 생성하여 문서들을 체계적으로 관리해보세요.',
+    createFirstCollection: '첫 컬렉션 만들기',
+    stats: {
+      collections: '컬렉션',
+      documents: '문서',
+      chunks: '청크',
+      documentsCount: '{{count}} 문서',
+      chunksCount: '{{count}} 청크'
+    },
+    table: {
+      collection: '컬렉션',
+      stats: '통계',
+      uuid: 'UUID',
+      metadata: '메타데이터'
+    },
+    deleteConfirm: {
+      title: '삭제 확인',
+      description: '정말로 선택한 컬렉션을 삭제하시겠습니까? 이 작업은 복구할 수 없습니다.',
+      collectionsToDelete: '삭제할 컬렉션 ({{count}}개):',
+      warningMessage: '삭제된 컬렉션의 모든 문서도 함께 삭제됩니다.',
+      deleteButton: '삭제',
+      deleting: '삭제 중...',
+      deleteSelected: '선택 항목 삭제'
+    },
+    popover: {
+      basicInfo: '기본 정보',
+      statistics: '통계'
+    },
+    messages: {
+      fetchError: '컬렉션 조회 실패',
+      deleteSuccess: '{{count}}개의 컬렉션이 성공적으로 삭제되었습니다.',
+      deleteFailed: '{{count}}개의 컬렉션 삭제에 실패했습니다.'
+    },
+    modal: {
+      createTitle: '새 컬렉션 만들기',
+      nameLabel: '컬렉션 이름',
+      namePlaceholder: '컬렉션 이름을 입력하세요',
+      descriptionLabel: '설명',
+      descriptionPlaceholder: '컬렉션 설명을 입력하세요 (선택사항)',
+      creating: '생성 중...',
+      createSuccess: '컬렉션이 성공적으로 생성되었습니다',
+      createError: '컬렉션 생성 실패'
+    }
+  },
+  documents: {
+    title: '문서 관리',
+    description: '컬렉션에 문서를 업로드하고 관리하세요',
+    selectCollection: '먼저 컬렉션을 선택해주세요',
+    uploadDocument: '문서 업로드',
+    noDocuments: '문서가 없습니다',
+    noDocumentsDescription: '이 컬렉션에 첫 번째 문서를 업로드하세요.',
+    uploadFirstDocument: '첫 문서 업로드',
+    table: {
+      fileName: '파일명',
+      uploadDate: '업로드 날짜',
+      chunks: '청크',
+      actions: '작업'
+    },
+    deleteConfirm: {
+      title: '문서 삭제',
+      description: '"{{fileName}}"을(를) 삭제하시겠습니까? 이 작업은 복구할 수 없습니다.',
+      warningMessage: '이 문서와 관련된 모든 청크도 함께 삭제됩니다.'
+    },
+    messages: {
+      uploadSuccess: '문서가 성공적으로 업로드되었습니다',
+      uploadError: '문서 업로드 실패',
+      deleteSuccess: '문서가 성공적으로 삭제되었습니다',
+      deleteError: '문서 삭제 실패',
+      fetchError: '문서 조회 실패'
+    },
+    modal: {
+      uploadTitle: '문서 업로드',
+      selectFile: '파일 선택',
+      supportedFormats: '지원 형식: PDF, TXT, MD, DOCX, HTML',
+      uploading: '업로드 중...',
+      processing: '문서 처리 중...'
+    }
+  },
+  search: {
+    title: '문서 검색',
+    description: '시맨틱 또는 키워드 검색을 사용하여 문서를 검색하세요',
+    selectCollection: '컬렉션 선택',
+    searchPlaceholder: '검색어를 입력하세요...',
+    searchButton: '검색',
+    searching: '검색 중...',
+    searchType: '검색 유형',
+    semanticSearch: '시맨틱 검색',
+    keywordSearch: '키워드 검색',
+    hybridSearch: '하이브리드 검색',
+    alphaValue: '알파 값 (0-1)',
+    noResults: '검색 결과가 없습니다',
+    results: '검색 결과',
+    relevanceScore: '관련도: {{score}}'
+  },
+  apiTester: {
+    title: 'API 테스터',
+    description: '인증을 사용하여 API 엔드포인트를 테스트하세요',
+    endpoint: '엔드포인트',
+    method: '메서드',
+    headers: '헤더',
+    body: '본문',
+    sendRequest: '요청 보내기',
+    response: '응답',
+    responseTime: '응답 시간: {{time}}ms',
+    status: '상태'
+  },
+  auth: {
+    signIn: '로그인',
+    signUp: '회원가입',
+    email: '이메일',
+    password: '비밀번호',
+    confirmPassword: '비밀번호 확인',
+    forgotPassword: '비밀번호를 잊으셨나요?',
+    alreadyHaveAccount: '이미 계정이 있으신가요?',
+    dontHaveAccount: '계정이 없으신가요?',
+    signInError: '로그인 실패',
+    signUpError: '회원가입 실패',
+    logoutSuccess: '로그아웃되었습니다'
+  },
+  theme: {
+    light: '라이트',
+    dark: '다크',
+    system: '시스템'
+  },
+  language: {
+    english: 'English',
+    korean: '한국어'
+  }
+}


### PR DESCRIPTION
## Summary
- Added comprehensive multi-language support for English and Korean
- Implemented language switching functionality with persistent storage
- Updated all UI components to use dynamic translations

## Changes
- **Language Context & Provider**: Created `LanguageProvider` to manage language state globally with localStorage persistence
- **Translation System**: 
  - Added translation files (`en.ts` and `ko.ts`) with all UI text
  - Created `useTranslation` hook for easy access to translations
  - Supports interpolation for dynamic values (e.g., `{{count}}`)
- **UI Updates**:
  - Added language selector dropdown in sidebar (above user account)
  - Updated sidebar navigation items with translations
  - Converted Collections page to use translations
  - Updated Create Collection modal with translated text
  - Translated user dropdown menu items
- **Default Settings**: English is set as the default language

## Test Plan
- [ ] Language selector dropdown appears in sidebar
- [ ] Switching between English/Korean updates all UI text immediately
- [ ] Language preference persists after page refresh
- [ ] All text in Collections page displays correctly in both languages
- [ ] Modal dialogs show translated content
- [ ] No console errors or warnings

## Screenshots
The language selector is positioned above the user account in the sidebar, allowing easy switching between English and Korean.